### PR TITLE
Enhancement: Remind user to replace the email in git config

### DIFF
--- a/src/services/messenger.py
+++ b/src/services/messenger.py
@@ -471,7 +471,7 @@ def process_postback(messenger, payload):
         messenger.send_action(typing_on)
         sleep(2)
         text = _(
-            u'don\'t forget to replace Steve\'s name with your own.')
+            u'Don\'t forget to replace Steve\'s name and email with your own.')
         messenger.send({'text': text}, 'RESPONSE')
         messenger.send_action(typing_on)
         sleep(2)


### PR DESCRIPTION
#### Is your pull request related to a problem? Please describe
As mentioned in #12, the chatbot doesn't reminds the user to replace the email id with his own. This PR fixes this issue i.e. #12 issue.

#### Describe the solution you'd like
Update the existing string which reminds the user to replace the name with his/her own name.

#### Checklist
- [x] My code follows the code style of this project.
- [x] I have read the **[CONTRIBUTING](https://github.com/fbdevelopercircles/open-source-edu-bot/blob/master/CONTRIBUTING.md)** document.
- [x] The title of my pull request is a short description of the requested changes.
