### PR TITLE
'ar_AR' matching with 'ar' #122

### DIFF
--- a/src/services/messenger.py
+++ b/src/services/messenger.py
@@ -46,8 +46,8 @@ mark_seen = SenderAction(sender_action="mark_seen").to_dict()
 
 @babel.localeselector
 def get_locale():
+
     if "locale" in user:
-        
         # ar_AR is not supported so we have to make an exception
         if user["locale"].startswith("ar_"):
             return "ar"

--- a/src/services/messenger.py
+++ b/src/services/messenger.py
@@ -47,6 +47,11 @@ mark_seen = SenderAction(sender_action="mark_seen").to_dict()
 @babel.localeselector
 def get_locale():
     if "locale" in user:
+        
+        # ar_AR is not supported so we have to make an exception
+        if user["locale"].startswith("ar_"):
+            return "ar"
+
         return user["locale"]
     return "en"
 


### PR DESCRIPTION
a solution for #122 because ar_AR is not directly supported by Babel